### PR TITLE
Hotfix/issue#4

### DIFF
--- a/src/common/browser/api/get-post-info.ts
+++ b/src/common/browser/api/get-post-info.ts
@@ -55,9 +55,17 @@ const getPostInfo: GetPostInfo = async function getPostInfo(page) {
           selector: 'button',
           text: 'Following',
         });
-        const unfollowSelector = unfollowButton
+        /**
+         * @author        Rosario Gueli <rosariogueli@hotmail.it>
+         * @description   This hotfix fixes the problem had where running this code on a page which is owned by the 
+         *                currenly logged in user, for example to like or comment this page. Since it's our page, we 
+         *                can't find a follow/unfollow button here, so the following code was generating an error and 
+         *                stopped the execution of the script. Now, the below code has been made conditional based on 
+         *                the unfollowButton selector above. If it doesn't find the follow/unfollow button, ignore it.
+         */
+        const unfollowSelector = unfollowButton ? unfollowButton
           .setscraperAttr('unfollowButton', 'unfollowButton')
-          .getSelectorByscraperAttr('unfollowButton');
+          .getSelectorByscraperAttr('unfollowButton') : '';
 
         return {
           unfollowSelector,

--- a/src/common/scraper/scraper.js
+++ b/src/common/scraper/scraper.js
@@ -26,8 +26,29 @@ const scraper = ((window, document) => {
       this.el = el;
     }
 
+    /**
+     * @author        Rosario Gueli <rosariogueli@hotmail.it>
+     * @description   IG has updated some of the elements structure, for example when using the comment function
+     *                the scraper could not find the button by its internal text, throwing the error: 
+     *                "Error: Evaluation failed: TypeError: Cannot read property 'parent' of null"
+     *                This is because IG have placed the text of this button inside the aria-label attribute of the span, 
+     *                the below hotfix is used in those areas where if text value was not found, gives this function 
+     *                second chance and try the element arial-label attibute:
+     *                XPath Example to find the Comment button: span[contains(@aria-label, "Comment")]
+     *                
+     */
+    aria_label(){
+      return String(this.getAttr('aria-label')).trim();
+    }
+
     text() {
-      return String(this.el.textContent).trim();
+      let res = String(this.el.textContent).trim();
+
+      if(!res){
+        res = this.aria_label();
+      }
+
+      return res;
     }
 
     get() {
@@ -35,7 +56,13 @@ const scraper = ((window, document) => {
     }
 
     html() {
-      return this.el.innerHTML;
+      let res = this.el.innerHTML;
+
+      if(!res){
+        res = this.aria_label();
+      }
+
+      return res;
     }
 
     dimensions() {


### PR DESCRIPTION
I've found and fixed 2 problems related to issue #4 : 
1 - IG have changed some of the elements that used to be selected by their text or html, they are now selected by the value in the area-label attributes. 
2 - The function that posts comments, if used on a link of the currently logged-in account, it was giving an error, because it was looking for the Follow/Unfollow buttons and could not find them breaking the rest of the execution. 